### PR TITLE
refactor(portal): migrate middelware into pokt-portal chart

### DIFF
--- a/charts/pokt-portal/Chart.lock
+++ b/charts/pokt-portal/Chart.lock
@@ -11,8 +11,5 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 12.1.0
-- name: portal-middleware
-  repository: https://pokt-foundation.github.io/charts
-  version: 0.0.2
-digest: sha256:c1a9b571b2b7d428d02fa616bd98254d1bf92785d853dc17849dc81c1fa66a88
-generated: "2022-11-09T14:26:50.203320836+02:00"
+digest: sha256:c9d6e1b6e963535d86ede95b253570dc8f9e3abd2cad0413bd4ec596f031f385
+generated: "2022-11-25T22:53:26.902806+02:00"

--- a/charts/pokt-portal/Chart.yaml
+++ b/charts/pokt-portal/Chart.yaml
@@ -20,13 +20,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.5
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.9"
+appVersion: "0.1.0"
 
 dependencies:
 - name: redis
@@ -45,19 +45,3 @@ dependencies:
   version: "12.1.0"
   repository: "https://charts.bitnami.com/bitnami"
   condition: postgresql.enabled
-- name: portal-middleware
-  version: "0.0.2"
-  repository: "https://pokt-foundation.github.io/charts"
-  condition: portal-middleware.enabled
-# - name: pokt-relay-meter
-#   version: "0.0.1"
-#   repository: "https://pokt-foundation.github.io/charts"
-#   condition: relayMeter.enabled
-# - name: pokt-rate-limiter
-#   version: "0.0.1"
-#   repository: "https://pokt-foundation.github.io/charts"
-#   condition: rateLimiter.enabled
-# - name: pokt-portal-workers
-#   version: "0.0.1"
-#   repository: "https://pokt-foundation.github.io/charts"
-#   condition: workers.enabled

--- a/charts/pokt-portal/templates/deployment.yaml
+++ b/charts/pokt-portal/templates/deployment.yaml
@@ -28,10 +28,53 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+      {{- if .Values.middleware.enabled }}
+        - name: middleware
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.middleware.image.repository }}:{{ .Values.middleware.image.tag | default "latest" }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.middleware.service.port }}
+              protocol: TCP
+          {{- if .Values.middleware.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.middleware.livenessProbe.path | default "/healthz" }}
+              port: http
+            initialDelaySeconds: {{ .Values.middleware.livenessProbe.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ .Values.middleware.livenessProbe.periodSeconds  | default 10 }}
+            timeoutSeconds: {{ .Values.middleware.livenessProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.middleware.livenessProbe.failureThreshold | default 6 }}
+            successThreshold: {{ .Values.middleware.livenessProbe.successThreshold | default 1}}
+          {{- end }}
+          {{- if .Values.middleware.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.middleware.readinessProbe.path | default "/healthz" }}
+              port: http
+            initialDelaySeconds: {{ .Values.middleware.readinessProbe.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ .Values.middleware.readinessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.middleware.readinessProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.middleware.readinessProbe.failureThreshold | default 6 }}
+            successThreshold: {{ .Values.middleware.readinessProbe.successThreshold | default 1 }}
+          {{- end }}
+          volumeMounts:
+          - mountPath: /config
+            name: config
+          env:
+            - name: CONFIG_FILE
+              value: /config/config.json
+            - name: BACKEND_URL
+              value: "http://localhost:{{ .Values.service.port }}"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- end }}
+        - name: api
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["npm", "run", "start"]
           ports:
@@ -73,3 +116,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        {{- if .Values.middleware.enabled }}
+        - name: config
+          configMap:
+            name: {{ include "pokt-portal.fullname" . }}-config
+        {{- end }}

--- a/charts/pokt-portal/templates/deployment.yaml
+++ b/charts/pokt-portal/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
+        ### portal-middleware sidecar container ###
       {{- if .Values.middleware.enabled }}
         - name: middleware
           securityContext:
@@ -36,7 +37,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.middleware.service.port }}
+              containerPort: 8080
               protocol: TCP
           {{- if .Values.middleware.livenessProbe.enabled }}
           livenessProbe:
@@ -61,16 +62,26 @@ spec:
             successThreshold: {{ .Values.middleware.readinessProbe.successThreshold | default 1 }}
           {{- end }}
           volumeMounts:
+          {{- if .Values.externalSecrets.enabled }}
+          - mountPath: "/config/"
+            name: external-secrets
+            readOnly: true
+          {{- else }}
           - mountPath: /config
             name: config
+          {{- end }}
           env:
             - name: CONFIG_FILE
               value: /config/config.json
             - name: BACKEND_URL
-              value: "http://localhost:{{ .Values.service.port }}"
+              value: "http://localhost:3000"
+            - name: PORT
+              value: "8080"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- end }}
+
+        ### portal-api sidecar container ###
         - name: api
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -79,7 +90,7 @@ spec:
           command: ["npm", "run", "start"]
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: 3000
               protocol: TCP
           {{- if .Values.probes.enabled }}
           livenessProbe:
@@ -103,7 +114,22 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          volumeMounts:
+
+        ### redis sidecar container ###
+        - name: redis
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: redis
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          env:
+            - name: ALLOW_EMPTY_PASSWORD
+              value: "yes"
+            - name: REDIS_TLS_ENABLED
+              value: "no"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -118,7 +144,13 @@ spec:
       {{- end }}
       volumes:
         {{- if .Values.middleware.enabled }}
+        {{- if .Values.externalSecrets.enabled }}
+        - name: external-secrets
+          secret:
+            secretName:  {{ include "pokt-portal.fullname" . }}-middleware-es
+        {{- else }}
         - name: config
           configMap:
-            name: {{ include "pokt-portal.fullname" . }}-config
+            name: {{ include "pokt-portal.fullname" . -}}-config
+        {{- end }}
         {{- end }}

--- a/charts/pokt-portal/templates/external-secret.yaml
+++ b/charts/pokt-portal/templates/external-secret.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.externalSecrets.enabled -}}
+---
 kind: ExternalSecret
 apiVersion: external-secrets.io/v1beta1
 metadata:
@@ -16,4 +17,24 @@ spec:
   - extract:
       key: {{ .Values.externalSecrets.key}}
       decodingStrategy: {{ .Values.externalSecrets.decodingStrategy }}
+{{- if .Values.middleware.enabled -}}
+---
+kind: ExternalSecret
+apiVersion: external-secrets.io/v1beta1
+metadata:
+  name: {{ include "pokt-portal.fullname" . }}
+spec:
+  refreshInterval: "60s"
+  secretStoreRef:
+    name: {{ include "pokt-portal.fullname" . }}-ss
+    kind: SecretStore
+  target:
+    name: {{ include "pokt-portal.fullname" . }}-middleware-es
+    deletionPolicy: "Delete"
+
+  dataFrom:
+  - extract:
+      key: {{ .Values.middleware.externalSecrets.key}}
+      decodingStrategy: {{ .Values.middleware.externalSecrets.decodingStrategy }}
+{{- end -}}
 {{- end -}}

--- a/charts/pokt-portal/templates/middelware-configmap.yaml
+++ b/charts/pokt-portal/templates/middelware-configmap.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.middleware.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pokt-portal.fullname" . -}}-config
+data:
+  config.json: |
+{{ .Values.middleware.config_json | indent 4 }}
+{{- end }}

--- a/charts/pokt-portal/templates/tests/test-connection.yaml
+++ b/charts/pokt-portal/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "pokt-portal.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "pokt-portal.fullname" . }}:{{ .Values.service.port }}/healthz']
   restartPolicy: Never

--- a/charts/pokt-portal/values.yaml
+++ b/charts/pokt-portal/values.yaml
@@ -4,6 +4,55 @@
 
 replicaCount: 1
 
+middleware:
+  enabled: true
+  image:
+    repository: pocketfoundation/portal-middleware
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+  config_json: |
+      {
+      	"chain_mappings": {
+      		"eth-mainnet": "eth",
+      		"eth-goerli": "eth"
+      	},
+      	"plugins_config": {
+      		"plugins": [
+      			"mev"
+      		],
+      		"mev": {
+      			"chains": {
+      				"avax": {
+      					"provider": "avax-provider",
+      					"sleep_duration": 1234
+      				}
+      			}
+      		}
+      	}
+      }
+
+  livenessProbe:
+    enabled: true
+    # initialDelaySeconds: 30
+    # periodSeconds: 10
+    # timeoutSeconds: 5
+    # failureThreshold: 6
+    # successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    # initialDelaySeconds: 5
+    # periodSeconds: 10
+    # timeoutSeconds: 5
+    # failureThreshold: 6
+    # successThreshold: 1
+
 image:
   repository: pocketfoundation/portal-api
   pullPolicy: IfNotPresent
@@ -164,12 +213,6 @@ env:
     # Datadog logging
     LOG_TO_DATADOG: "false"
     DATADOG_API_KEY: myApiKey
-
-## @section portal-middleware subchart parameters
-## @param portal-middleware .enabled Deploy portal-middleware  subchart
-##
-portal-middleware:
-  enabled: true
 
 ## @section redis subcharts parameters
 ## @param redis.enabled Deploy redis subchart

--- a/charts/pokt-portal/values.yaml
+++ b/charts/pokt-portal/values.yaml
@@ -10,11 +10,7 @@ middleware:
     repository: pocketfoundation/portal-middleware
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: ""
-
-  service:
-    type: ClusterIP
-    port: 8080
+    tag: "0.0.21"
 
   config_json: |
       {
@@ -38,7 +34,7 @@ middleware:
       }
 
   livenessProbe:
-    enabled: true
+    enabled: false
     # initialDelaySeconds: 30
     # periodSeconds: 10
     # timeoutSeconds: 5
@@ -46,12 +42,17 @@ middleware:
     # successThreshold: 1
 
   readinessProbe:
-    enabled: true
+    enabled: false
     # initialDelaySeconds: 5
     # periodSeconds: 10
     # timeoutSeconds: 5
     # failureThreshold: 6
     # successThreshold: 1
+
+  externalSecrets:
+    # # external secret key
+    key: "some/path/secret"
+    decodginStrategy: "Auto"
 
 image:
   repository: pocketfoundation/portal-api
@@ -88,17 +89,19 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 3000
+  # must be 3000 for api OR 8080 for middleware
+  port: 8080
 
 probes:
   enabled: false
 
 ingress:
+  # must be one of api or middleware
   enabled: false
   className: ""
   annotations: {}
   hosts:
-    - host: mydomain.com
+    - host: "*.localhost"
       paths:
         - path: /
           pathType: ImplementationSpecific
@@ -134,19 +137,19 @@ affinity: {}
 
 externalSecrets:
   enabled: false
-  # # external secret key
-  # key: "some/path/secret"
-  # decodginStrategy: Auto
-  # # secret-store config
-  # secretStore: "vault"
-  # vault:
-  #   server: "https://vault:8200"
-  #   mountPath: "k8s-mount-path"
-  #   namespace: "our/namespace/"
-  #   serviceAccount: "portal-api"
-  #   role: "my-role"
-  #   path: "path/"
-  #   version: "v1"
+  # external secret key
+  key: "some/path/secret"
+  decodginStrategy: Auto
+  # secret-store config
+  secretStore: "vault"
+  vault:
+    server: "https://vault:8200"
+    mountPath: "k8s-mount-path"
+    namespace: "our/namespace/"
+    serviceAccount: "portal-api"
+    role: "my-role"
+    path: "path/"
+    version: "v1"
 
 
 # Environment variable listing
@@ -170,7 +173,7 @@ env:
     REMOTE_REDIS_ENDPOINT: "redis-master:6379"
 
     # local cache
-    LOCAL_REDIS_ENDPOINT: "redis-master:6379"
+    LOCAL_REDIS_ENDPOINT: "localhost:6379"
     REDIS_LOCAL_TTL_FACTOR: "1"
 
     # Influx DB


### PR DESCRIPTION
migrates middleware chart into the pokt-portal helm chart to address some concerns around latency between middleware and the portal api service.

By running side-container pattern, we should be able to reduce pod-to-pod latency drastically
