### PR TITLE
Removed namespace to fix Vault connection and updated Chart version

### DIFF
--- a/charts/pokt-http-db/Chart.yaml
+++ b/charts/pokt-http-db/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pokt-http-db/templates/secret-store.yaml
+++ b/charts/pokt-http-db/templates/secret-store.yaml
@@ -14,7 +14,6 @@ spec:
           role: {{ .Values.externalSecrets.vault.role }}
           serviceAccountRef:
             name: {{ .Values.externalSecrets.vault.serviceAccount }}
-      namespace: {{ .Values.externalSecrets.vault.namespace }}
       path: {{ .Values.externalSecrets.vault.path }}
       server: {{ .Values.externalSecrets.vault.server }}
       version: {{ .Values.externalSecrets.vault.version }}

--- a/charts/pokt-portal/Chart.yaml
+++ b/charts/pokt-portal/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pokt-portal/templates/secret-store.yaml
+++ b/charts/pokt-portal/templates/secret-store.yaml
@@ -14,7 +14,6 @@ spec:
           role: {{ .Values.externalSecrets.vault.role }}
           serviceAccountRef:
             name: {{ .Values.externalSecrets.vault.serviceAccount }}
-      namespace: {{ .Values.externalSecrets.vault.namespace }}
       path: {{ .Values.externalSecrets.vault.path }}
       server: {{ .Values.externalSecrets.vault.server }}
       version: {{ .Values.externalSecrets.vault.version }}

--- a/charts/pokt-relay-meter/Chart.yaml
+++ b/charts/pokt-relay-meter/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pokt-relay-meter/templates/secret-store.yaml
+++ b/charts/pokt-relay-meter/templates/secret-store.yaml
@@ -13,7 +13,6 @@ spec:
           role: {{ .Values.externalSecrets.vault.role }}
           serviceAccountRef:
             name: {{ .Values.externalSecrets.vault.serviceAccount }}
-      namespace: {{ .Values.externalSecrets.vault.namespace }}
       path: {{ .Values.externalSecrets.vault.path }}
       server: {{ .Values.externalSecrets.vault.server }}
       version: {{ .Values.externalSecrets.vault.version }}

--- a/charts/portal-middleware/Chart.yaml
+++ b/charts/portal-middleware/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/portal-middleware/templates/secret-store.yaml
+++ b/charts/portal-middleware/templates/secret-store.yaml
@@ -13,7 +13,6 @@ spec:
           role: {{ .Values.externalSecrets.vault.role }}
           serviceAccountRef:
             name: {{ .Values.externalSecrets.vault.serviceAccount }}
-      namespace: {{ .Values.externalSecrets.vault.namespace }}
       path: {{ .Values.externalSecrets.vault.path }}
       server: {{ .Values.externalSecrets.vault.server }}
       version: {{ .Values.externalSecrets.vault.version }}

--- a/charts/portal-ui-backend/Chart.yaml
+++ b/charts/portal-ui-backend/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/portal-ui-backend/templates/secret-store.yaml
+++ b/charts/portal-ui-backend/templates/secret-store.yaml
@@ -14,7 +14,6 @@ spec:
           role: {{ .Values.externalSecrets.vault.role }}
           serviceAccountRef:
             name: {{ .Values.externalSecrets.vault.serviceAccount }}
-      namespace: {{ .Values.externalSecrets.vault.namespace }}
       path: {{ .Values.externalSecrets.vault.path }}
       server: {{ .Values.externalSecrets.vault.server }}
       version: {{ .Values.externalSecrets.vault.version }}


### PR DESCRIPTION
# TL;DR

This PR fixes the Tailscale connection as commented in the following [conversation](https://discord.com/channels/@me/1049208509054599209/1050150666598895676). This fix removes the namespace from `secret-store.yml` template in order to make successful connection to Vault.