### PR TITLE
Enable discord token env variable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     # -   id: check-yaml
     -   id: check-added-large-files
 - repo: https://github.com/pokt-foundation/charts
-  rev: docs-hook-0.1.1
+  rev: docs-hook-0.1.2
   hooks:
     - id: helm-docs
       args: []

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     # -   id: check-yaml
     -   id: check-added-large-files
 - repo: https://github.com/pokt-foundation/charts
-  rev: docs-hook-0.1.0
+  rev: docs-hook-0.1.1
   hooks:
     - id: helm-docs
       args: []

--- a/charts/release-watch/Chart.yaml
+++ b/charts/release-watch/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/release-watch/Chart.yaml
+++ b/charts/release-watch/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/release-watch/README.md
+++ b/charts/release-watch/README.md
@@ -1,6 +1,6 @@
 # release-watch
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/release-watch/README.md
+++ b/charts/release-watch/README.md
@@ -1,6 +1,6 @@
 # release-watch
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -15,7 +15,10 @@ A Helm chart for Kubernetes
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | additionalManifests | list | `[]` |  |
-| env | list | `[]` |  |
+| env[0].name | string | `"DISCORD_TOKEN"` |  |
+| env[0].valueFrom.secretKeyRef.key | string | `"DISCORD_TOKEN"` |  |
+| env[0].valueFrom.secretKeyRef.name | string | `"release-watch"` |  |
+| env[0].valueFrom.secretKeyRef.optional | bool | `false` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"pocketfoundation/release-watch"` |  |

--- a/charts/release-watch/README.md
+++ b/charts/release-watch/README.md
@@ -1,6 +1,6 @@
 # release-watch
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -16,9 +16,7 @@ A Helm chart for Kubernetes
 |-----|------|---------|-------------|
 | additionalManifests | list | `[]` |  |
 | env[0].name | string | `"DISCORD_TOKEN"` |  |
-| env[0].valueFrom.secretKeyRef.key | string | `"DISCORD_TOKEN"` |  |
-| env[0].valueFrom.secretKeyRef.name | string | `"release-watch"` |  |
-| env[0].valueFrom.secretKeyRef.optional | bool | `false` |  |
+| env[0].value | string | `"foo"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"pocketfoundation/release-watch"` |  |

--- a/charts/release-watch/values.yaml
+++ b/charts/release-watch/values.yaml
@@ -23,7 +23,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: "release-watch"
 
-env: []
+env:
   # - name: GH_USERNAME
   #   valueFrom:
   #     secretKeyRef:
@@ -36,12 +36,12 @@ env: []
   #       name: release-watch
   #       key: GH_TOKEN
   #       optional: false
-  # - name: DISCORD_TOKEN
-  #   valueFrom:
-  #     secretKeyRef:
-  #       name: release-watch
-  #       key: DISCORD_TOKEN
-  #       optional: false
+   - name: DISCORD_TOKEN
+     valueFrom:
+       secretKeyRef:
+         name: release-watch
+         key: DISCORD_TOKEN
+         optional: false
 
 additionalManifests: []
   # - apiVersion: external-secrets.io/v1beta1

--- a/charts/release-watch/values.yaml
+++ b/charts/release-watch/values.yaml
@@ -36,12 +36,12 @@ env:
   #       name: release-watch
   #       key: GH_TOKEN
   #       optional: false
-   - name: DISCORD_TOKEN
-     valueFrom:
-       secretKeyRef:
-         name: release-watch
-         key: DISCORD_TOKEN
-         optional: false
+  - name: DISCORD_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: release-watch
+        key: DISCORD_TOKEN
+        optional: false
 
 additionalManifests: []
   # - apiVersion: external-secrets.io/v1beta1

--- a/charts/release-watch/values.yaml
+++ b/charts/release-watch/values.yaml
@@ -37,11 +37,7 @@ env:
   #       key: GH_TOKEN
   #       optional: false
   - name: DISCORD_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: release-watch
-        key: DISCORD_TOKEN
-        optional: false
+    value: foo
 
 additionalManifests: []
   # - apiVersion: external-secrets.io/v1beta1

--- a/git-hook/helm-docs
+++ b/git-hook/helm-docs
@@ -7,4 +7,4 @@ if ! command -v helm-docs > /dev/null 2>&1; then
     exit 1
 fi
 
-git diff --dirstat=files,0 | awk '{print $2}' | while read chart; do pushd $chart && helm-docs . && popd; done
+git diff --dirstat=files,0 HEAD | awk '{print $2}' | while read chart; do pushd $chart && helm-docs && popd; done

--- a/git-hook/helm-docs
+++ b/git-hook/helm-docs
@@ -7,4 +7,4 @@ if ! command -v helm-docs > /dev/null 2>&1; then
     exit 1
 fi
 
-git diff --dirstat=files,0 | awk '{print $2}' | while read chart; do helm-docs -g $chart; done
+git diff --dirstat=files,0 | awk '{print $2}' | while read chart; do pushd $chart && helm-docs . && popd; done


### PR DESCRIPTION
# TL;DR

Uncommented `DISCORD_TOKEN` env variable in order to pass test-linter CI step.

## Summary

- Replaced empty env with `DISCORD_TOKEN` instead.
- Modified custom `helm-docs` hook since it wasn't properly catching all the changes and updating documentation.
- Bumped hook and chart version.

## Related tasks

N/A