### PR TITLE
Resources block and control flow for middleware and redis

### DIFF
--- a/charts/pokt-portal/Chart.yaml
+++ b/charts/pokt-portal/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.13
+version: 0.1.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pokt-portal/README.md
+++ b/charts/pokt-portal/README.md
@@ -1,6 +1,6 @@
 # pokt-portal
 
-![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart for deploying the POKT Portal API services
 
@@ -86,6 +86,7 @@ A Helm chart for deploying the POKT Portal API services
 | localRedis.envs.ALLOW_EMPTY_PASSWORD | string | `"yes"` |  |
 | localRedis.image.repository | string | `"redis"` |  |
 | localRedis.image.tag | string | `"6.2-alpine"` |  |
+| localRedis.resources | object | `{}` |  |
 | middleware.config_json | string | `"{\n  \"backend_url\": \"http://localhost:3000\",\n\t\"chain_mappings\": {\n\t\t\"eth-mainnet\": \"eth\",\n\t\t\"eth-goerli\": \"eth\"\n\t},\n\t\"plugins_config\": {\n\t\t\"plugins\": [\n\t\t\t\"mev\"\n\t\t],\n\t\t\"mev\": {\n\t\t\t\"chains\": {\n\t\t\t\t\"avax\": {\n\t\t\t\t\t\"provider\": \"avax-provider\",\n\t\t\t\t\t\"sleep_duration\": 1234\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n}\n"` |  |
 | middleware.enabled | bool | `true` |  |
 | middleware.envs.BACKEND_URL | string | `"http://localhost:3000"` |  |
@@ -96,6 +97,7 @@ A Helm chart for deploying the POKT Portal API services
 | middleware.image.tag | string | `"0.0.49"` |  |
 | middleware.livenessProbe.enabled | bool | `true` |  |
 | middleware.readinessProbe.enabled | bool | `true` |  |
+| middleware.resources | object | `{}` |  |
 | middleware.startupProbe.enabled | bool | `true` |  |
 | mongodb.auth.databases[0] | string | `"gateway"` |  |
 | mongodb.auth.passwords[0] | string | `"P0K7m0ngod8"` |  |

--- a/charts/pokt-portal/README.md
+++ b/charts/pokt-portal/README.md
@@ -1,6 +1,6 @@
 # pokt-portal
 
-![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart for deploying the POKT Portal API services
 

--- a/charts/pokt-portal/templates/deployment.yaml
+++ b/charts/pokt-portal/templates/deployment.yaml
@@ -87,7 +87,11 @@ spec:
             - name: PORT
               value: "{{ .Values.service.port | default "8080" }}"
           resources:
+          {{- if not .Values.middleware.resources }}
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- else }}
+            {{- toYaml .Values.middleware.resources | nindent 12 }}
+          {{- end }}
       {{- end }}
 
         ### portal-api sidecar container ###
@@ -153,7 +157,11 @@ spec:
           env:
           {{- include "helpers.redis-env-variables" . | indent 12 }}
           resources:
+          {{- if not .Values.localRedis.resources }}
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- else }}
             {{- toYaml .Values.localRedis.resources | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/pokt-portal/values.yaml
+++ b/charts/pokt-portal/values.yaml
@@ -68,6 +68,9 @@ middleware:
   envs:
     BACKEND_URL: "http://localhost:3000"
 
+  ### middleware resource definition
+  resources: {}
+
 image:
   repository: pocketfoundation/portal-api
   pullPolicy: IfNotPresent


### PR DESCRIPTION
# TL;DR

Middleware and Redis containers now have resource block definition to select which resources to take for requests/limits.

## Summary

This PR aims to solve the issue where all pod containers take the resources definition from chart block and can't selectively get their own resource request/limit definition.

## Related tasks

N/A