### PR TITLE
Template update with HPA behavior block

### DIFF
--- a/charts/pokt-portal/Chart.yaml
+++ b/charts/pokt-portal/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.14
+version: 0.1.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pokt-portal/README.md
+++ b/charts/pokt-portal/README.md
@@ -1,6 +1,6 @@
 # pokt-portal
 
-![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart for deploying the POKT Portal API services
 

--- a/charts/pokt-portal/templates/_helpers.tpl
+++ b/charts/pokt-portal/templates/_helpers.tpl
@@ -94,3 +94,23 @@ Create normal env vars from list
   value: {{ $val | quote }}
 {{- end }}
 {{- end }}
+
+{{/*
+Autoscaling behavior definition
+*/}}
+{{- define "pokt-portal.autoscaling-behavior" -}}
+{{- $stabilizationWindow := 300 }}
+{{- $policyMax := Max }}
+{{- $policyMin := Min }}
+behavior:
+  scaleDown:
+    stabilizationWindowSeconds: {{ .Values.autoscaling.policy.behavior.scaleDown.stabilizationWindowSeconds | default $stabilizationWindow }}
+    selectPolicy: {{ .Values.autoscaling.policy.behavior.scaleDown.selectPolicy | default $policyMin }}
+    policies:
+      {{- toYaml .Values.autoscaling.policy.behavior.scaleDown.policies }}
+  scaleUp:
+    stabilizationWindowSeconds: {{ .Values.autoscaling.policy.behavior.scaleUp.stabilizationWindowSeconds | default $stabilizationWindow }}
+    selectPolicy: {{ .Values.autoscaling.policy.behavior.scaleUp.selectPolicy | default $policyMax }}
+    policies:
+      {{- toYaml .Values.autoscaling.policy.behavior.scaleUp.policies }}
+{{- end }}

--- a/charts/pokt-portal/templates/_helpers.tpl
+++ b/charts/pokt-portal/templates/_helpers.tpl
@@ -104,13 +104,13 @@ Autoscaling behavior definition
 {{- $policyMin := "Min" }}
 behavior:
   scaleDown:
-    stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleDown.stabilizationWindowSeconds | default $stabilizationWindow }}
-    selectPolicy: {{ .Values.autoscaling.behavior.scaleDown.selectPolicy | default $policyMin }}
+    stabilizationWindowSeconds: {{ .Values.autoscaling.policies.behavior.scaleDown.stabilizationWindowSeconds | default $stabilizationWindow }}
+    selectPolicy: {{ .Values.autoscaling.policies.behavior.scaleDown.selectPolicy | default $policyMin }}
     policies:
-      {{- toYaml .Values.autoscaling.behavior.scaleDown.policies }}
+      {{- toYaml .Values.autoscaling.policies.behavior.scaleDown.policies }}
   scaleUp:
-    stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleUp.stabilizationWindowSeconds | default $stabilizationWindow }}
-    selectPolicy: {{ .Values.autoscaling.behavior.scaleUp.selectPolicy | default $policyMax }}
+    stabilizationWindowSeconds: {{ .Values.autoscaling.policies.behavior.scaleUp.stabilizationWindowSeconds | default $stabilizationWindow }}
+    selectPolicy: {{ .Values.autoscaling.policies.behavior.scaleUp.selectPolicy | default $policyMax }}
     policies:
-      {{- toYaml .Values.autoscaling.behavior.scaleUp.policies }}
+      {{- toYaml .Values.autoscaling.policies.behavior.scaleUp.policies }}
 {{- end }}

--- a/charts/pokt-portal/templates/_helpers.tpl
+++ b/charts/pokt-portal/templates/_helpers.tpl
@@ -100,17 +100,17 @@ Autoscaling behavior definition
 */}}
 {{- define "pokt-portal.autoscaling-behavior" -}}
 {{- $stabilizationWindow := 300 }}
-{{- $policyMax := Max }}
-{{- $policyMin := Min }}
+{{- $policyMax := "Max" }}
+{{- $policyMin := "Min" }}
 behavior:
   scaleDown:
-    stabilizationWindowSeconds: {{ .Values.autoscaling.policy.behavior.scaleDown.stabilizationWindowSeconds | default $stabilizationWindow }}
-    selectPolicy: {{ .Values.autoscaling.policy.behavior.scaleDown.selectPolicy | default $policyMin }}
+    stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleDown.stabilizationWindowSeconds | default $stabilizationWindow }}
+    selectPolicy: {{ .Values.autoscaling.behavior.scaleDown.selectPolicy | default $policyMin }}
     policies:
-      {{- toYaml .Values.autoscaling.policy.behavior.scaleDown.policies }}
+      {{- toYaml .Values.autoscaling.behavior.scaleDown.policies }}
   scaleUp:
-    stabilizationWindowSeconds: {{ .Values.autoscaling.policy.behavior.scaleUp.stabilizationWindowSeconds | default $stabilizationWindow }}
-    selectPolicy: {{ .Values.autoscaling.policy.behavior.scaleUp.selectPolicy | default $policyMax }}
+    stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleUp.stabilizationWindowSeconds | default $stabilizationWindow }}
+    selectPolicy: {{ .Values.autoscaling.behavior.scaleUp.selectPolicy | default $policyMax }}
     policies:
-      {{- toYaml .Values.autoscaling.policy.behavior.scaleUp.policies }}
+      {{- toYaml .Values.autoscaling.behavior.scaleUp.policies }}
 {{- end }}

--- a/charts/pokt-portal/templates/hpa.yaml
+++ b/charts/pokt-portal/templates/hpa.yaml
@@ -10,17 +10,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "pokt-portal.fullname" . }}
-  behavior:
-    scaleDown:
-      stabilizationWindowSeconds: {{ .Values.autoscaling.scaleDown.stabilizationWindowSeconds | default 300 }}
-      selectPolicy: {{ .Values.autoscaling.scaleDown.policy | default "Min" }}
-      policies:
-        {{- toYaml .Values.autoscaling.scaleDown.policies | nindent 8 }}
-    scaleUp:
-      stabilizationWindowSeconds: {{ .Values.autoscaling.scaleUp.stabilizationWindowSeconds | default 0 }}
-      selectPolicy: {{ .Values.autoscaling.scaleDown.policy | default "Max" }}
-      policies:
-        {{- toYaml .Values.autoscaling.scaleUp.policies | nindent 8 }}
+  {{- if .Values.autoscaling.policies.enabled }}
+  {{- include "pokt-portal.autoscaling-behavior" . | nindent 2 }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/charts/pokt-portal/templates/hpa.yaml
+++ b/charts/pokt-portal/templates/hpa.yaml
@@ -10,6 +10,17 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "pokt-portal.fullname" . }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.autoscaling.scaleDown.stabilizationWindowSeconds | default 300 }}
+      selectPolicy: {{ .Values.autoscaling.scaleDown.policy | default "Min" }}
+      policies:
+        {{- toYaml .Values.autoscaling.scaleDown.policies | nindent 8 }}
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.autoscaling.scaleUp.stabilizationWindowSeconds | default 0 }}
+      selectPolicy: {{ .Values.autoscaling.scaleDown.policy | default "Max" }}
+      policies:
+        {{- toYaml .Values.autoscaling.scaleUp.policies | nindent 8 }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/charts/pokt-portal/templates/hpa.yaml
+++ b/charts/pokt-portal/templates/hpa.yaml
@@ -12,6 +12,7 @@ spec:
     name: {{ include "pokt-portal.fullname" . }}
   {{- if .Values.autoscaling.policies.enabled }}
   {{- include "pokt-portal.autoscaling-behavior" . | nindent 2 }}
+  {{- end }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/charts/pokt-portal/values.yaml
+++ b/charts/pokt-portal/values.yaml
@@ -176,31 +176,32 @@ resources: {}
 #  behavior block and stabilization window.
 autoscaling:
   enabled: false
-  ## Policies flag enables autoscaling behavior based on a set of scale
+  ## Policies block enables autoscaling behavior based on a set of scale
   ## up/down policies. It expects at least one policy for scale up and
   ## scale down respecitvely. This will allow to fine tune scaling events
   ## and reduce throttling or flapping when scale occurs. Bear in mind
   ## getting this section to work right might require a lot of back
   ## and forth tweaking, trial and error.
-  # policies: false
-  # behavior:
-  #   scaleDown:
-  #     stabilizationWindowSeconds: 300
-  #     selectPolicy: Min
-  #     policies:
-  #        - type: Percent
-  #          value: 80
-  #          periodSeconds: 60
-  #   scaleUp:
-  #     stabilizationWindowSeconds: 0
-  #     selectPolicy: Max
-  #     policies:
-  #       - type: Percent
-  #         value: 80
-  #         periodSeconds: 30
-  #       - type: Pods
-  #         value: 5
-  #         periodSeconds: 30
+  # policies:
+  #   enabled: false
+  #   behavior:
+  #     scaleDown:
+  #       stabilizationWindowSeconds: 300
+  #       selectPolicy: Min
+  #       policies:
+  #         - type: Percent
+  #           value: 80
+  #           periodSeconds: 60
+  #     scaleUp:
+  #       stabilizationWindowSeconds: 0
+  #       selectPolicy: Max
+  #       policies:
+  #         - type: Percent
+  #           value: 80
+  #           periodSeconds: 30
+  #         - type: Pods
+  #           value: 5
+  #           periodSeconds: 30
   # minReplicas: 3
   # maxReplicas: 100
   # targetCPUUtilizationPercentage: 65

--- a/charts/pokt-portal/values.yaml
+++ b/charts/pokt-portal/values.yaml
@@ -173,13 +173,16 @@ resources: {}
   #   memory: 128Mi
 
 ## Autoscaling definition. This section includes HPA with scale up/down
-#  behavior block and stabilization window. This is included by default
-#  in this section but may be later on enabled/disabled via template.
-#  When using HPA behavior using multiple policies that can reflect the
-#  different scale scenarios a deployment could face will provide the
-#  best scaling results. This will require a lot of back and forth tweaking.
+#  behavior block and stabilization window.
 autoscaling:
   enabled: false
+  ## Policies flag enables autoscaling behavior based on a set of scale
+  ## up/down policies. It expects at least one policy for scale up and
+  ## scale down respecitvely. This will allow to fine tune scaling events
+  ## and reduce throttling or flapping when scale occurs. Bear in mind
+  ## getting this section to work right might require a lot of back
+  ## and forth tweaking, trial and error.
+  # policies: false
   # behavior:
   #   scaleDown:
   #     stabilizationWindowSeconds: 300

--- a/charts/pokt-portal/values.yaml
+++ b/charts/pokt-portal/values.yaml
@@ -172,8 +172,32 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+## Autoscaling definition. This section includes HPA with scale up/down
+#  behavior block and stabilization window. This is included by default
+#  in this section but may be later on enabled/disabled via template.
+#  When using HPA behavior using multiple policies that can reflect the
+#  different scale scenarios a deployment could face will provide the
+#  best scaling results. This will require a lot of back and forth tweaking.
 autoscaling:
   enabled: false
+  # behavior:
+  #   scaleDown:
+  #     stabilizationWindowSeconds: 300
+  #     selectPolicy: Min
+  #     policies:
+  #        - type: Percent
+  #          value: 80
+  #          periodSeconds: 60
+  #   scaleUp:
+  #     stabilizationWindowSeconds: 0
+  #     selectPolicy: Max
+  #     policies:
+  #       - type: Percent
+  #         value: 80
+  #         periodSeconds: 30
+  #       - type: Pods
+  #         value: 5
+  #         periodSeconds: 30
   # minReplicas: 3
   # maxReplicas: 100
   # targetCPUUtilizationPercentage: 65


### PR DESCRIPTION
# TL;DR

This PR includes `behavior` block to HPA template.

## Summary

In order to fine-tune pod scaling and improve the mechanism and behavior under which we want to scale up/down, we need to include a set of policies that can reflect the scenarios that will make the deployment scale in/out accordingly. This PR adds the `behavior` block to HPA template in order to start working on such fine-tune scaling.

## TODO

This is just an initial effort, and will require a lot of back and forth tweaking and tuning in the Argo template manifest.

## Related tasks

[T-17642](https://pokt.height.app/T-17642)