### PR TITLE
Fix pvc in deployment

### DIFF
--- a/charts/universal-helm/Chart.yaml
+++ b/charts/universal-helm/Chart.yaml
@@ -10,5 +10,5 @@ version: 0.0.13
 appVersion: "1.16.0"
 
 maintainers:
-  - name: pokt-inc
-  - name: vlad
+  - name: pokt-foundation
+  - name: vlad-she

--- a/charts/universal-helm/Chart.yaml
+++ b/charts/universal-helm/Chart.yaml
@@ -5,7 +5,6 @@ description: A Universal Helm chart
 type: application
 
 version: 0.0.13
-
 # Not compatible with 0.0.1 due to change container.command
 
 appVersion: "1.16.0"

--- a/charts/universal-helm/Chart.yaml
+++ b/charts/universal-helm/Chart.yaml
@@ -4,7 +4,8 @@ description: A Universal Helm chart
 
 type: application
 
-version: 0.0.12
+version: 0.0.13
+
 # Not compatible with 0.0.1 due to change container.command
 
 appVersion: "1.16.0"

--- a/charts/universal-helm/templates/deployments.yaml
+++ b/charts/universal-helm/templates/deployments.yaml
@@ -196,28 +196,10 @@ spec:
           {{- end }}
         {{- end }}
 
-  {{- if $dpl.persistence }} {{ if $dpl.persistence.volumeClaimTemplates}}
-  {{with $dpl.persistence.volumeClaimTemplates}}
-  {{- if and .storageClassName .size .volumeMountPath }}
-  volumeClaimTemplates:
-    - metadata:
-        name: {{ $volumeName }}
-      spec:
-        {{- if .storageClassName }}
-        storageClassName: {{ .storageClassName }}
-        {{- end }}
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requedpl:
-            storage: {{ .size | quote }}
-        {{- if .gcpVolumeSnapshot }}
-        dataSource:
-          name: {{ .gcpVolumeSnapshot | quote }}
-          kind: VolumeSnapshot
-          apiGroup: snapshot.storage.k8s.io
-        {{- end }}
-  {{- end }}
-  {{end}}
-  {{end}}{{end}}
+        {{- if $dpl.persistence }} {{ if $dpl.persistence.volumeClaimTemplates}} {{if $dpl.persistence.volumeClaimTemplates.volumeMountPath }}
+        - name: {{ $volumeName }}
+          persistentVolumeClaim:
+              claimName: {{ $volumeName }}
+          {{- end }}{{end}}{{end}}
+
 {{ end }} {{/* #range $ndpl, $dpl := $.Values.deployments */}}

--- a/charts/universal-helm/templates/volumeClaimTemplates.yaml
+++ b/charts/universal-helm/templates/volumeClaimTemplates.yaml
@@ -1,0 +1,41 @@
+{{- range $ndpl, $dpl := $.Values.deployments }}
+
+{{- $volumeName := printf "%s-data" $ndpl }}
+
+{{- if $dpl.persistence }}
+{{- if $dpl.persistence.volumeClaimTemplates }}
+{{with $dpl.persistence.volumeClaimTemplates}}
+{{- if and .storageClassName .size .volumeMountPath }}
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $volumeName }}
+  labels:
+    {{- include "universal-helm.labels" $ | nindent 4 }}
+    {{- with $dpl.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with $dpl.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  storageClassName: {{ .storageClassName }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requedpl:
+      storage: {{ .size | quote }}
+  {{- if .gcpVolumeSnapshot }}
+  dataSource:
+    name: {{ .gcpVolumeSnapshot | quote }}
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- end }}


### PR DESCRIPTION
 volumeClaimTemplates cannot be used directly in Deployments. The volumeClaimTemplates field is specific to the StatefulSet resource, not Deployments.
 
 to use PersistentVolumeClaims in a Deployment, we need to create the PVCs separately and then reference them in the volumes field of the Deployment's Pod template which is the goal of this PR