### PR TITLE
add sts to universal helms

### DIFF
--- a/charts/universal-helm/Chart.yaml
+++ b/charts/universal-helm/Chart.yaml
@@ -4,7 +4,7 @@ description: A Universal Helm chart
 
 type: application
 
-version: 0.0.15
+version: 0.0.16
 # Not compatible with 0.0.1 due to change container.command
 
 appVersion: "1.16.0"

--- a/charts/universal-helm/templates/statefulsets.yaml
+++ b/charts/universal-helm/templates/statefulsets.yaml
@@ -1,0 +1,242 @@
+{{- range $ksts, $sts := $.Values.statefulset }}
+{{- $volumeName := printf "%s-data" $sts.name }}
+
+{{- $stsCMNames := list }}
+{{- range $cntnr := $sts.containers }}
+  {{- range $cm := $cntnr.mountConfigMaps }}
+    {{- $stsCMNames = append $stsCMNames $cm.name  }}
+  {{- end }}
+{{- end }}
+
+{{- $stsSecNames := list }}
+{{- range $cntnr := $sts.containers }}
+  {{- range $sec := $cntnr.mountSecrets }}
+    {{- $stsSecNames = append $stsSecNames $sec.name  }}
+  {{- end }}
+{{- end }}
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $sts.name }}
+  labels:
+    {{- include "universal-helm.labels" $ | nindent 4 }}
+    {{- with $sts.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  serviceName: {{ template "universal-helm.fullname" $ }}-svc
+  podManagementPolicy: {{ default "Parallel" $.Values.global.podManagementPolicy }}
+  updateStrategy:
+    type: {{ default "RollingUpdate" $.Values.global.updateStrategy }}
+    {{- if (eq "Recreate" (default "RollingUpdate" $.Values.global.updateStrategy)) }}
+    rollingUpdate: null
+    {{- end }}
+  selector:
+    matchLabels:
+      statefulsetname: {{ $sts.name }}
+  replicas: {{ default 1 $sts.replicas }}
+  template:
+    metadata:
+      name: {{ template "universal-helm.fullname" $ }}
+      labels:
+        {{- include "universal-helm.labels" $ | nindent 8 }}
+        {{- with $sts.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        statefulsetname: {{ $sts.name }}
+      {{- with $sts.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      terminationGracePeriodSeconds: {{ default 180 $.Values.global.terminationGracePeriodSeconds }}
+      {{- with $sts.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $sts.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $sts.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $sts.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with $.Values.global.securityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.global.serviceAccount.name }}
+      serviceAccountName: {{ . }}
+      {{- end }}
+
+      initContainers:
+      {{- range $kcntnr, $cntnr := $sts.containers }}
+      {{- if or $cntnr.mountConfigMaps $cntnr.mountSecrets }}
+      {{ $cmPref := "/cm" }}
+      {{ $secPref := "/sec" }}
+      - name: cp-configs
+        image: alpine:latest
+        workingDir: {{ $sts.persistence.volumeMountPath }}
+        command:
+          - 'sh'
+          - '-c'
+          - |
+            set -exu
+          {{- range $cm := (concat (default (list ) $cntnr.mountConfigMaps) (default (list ) $cntnr.mountSecrets)) }}
+            mkdir -p {{$cm.targetPath}}
+            cp -f /{{$cm.name}}/* {{$cm.targetPath}}
+          {{- end }}
+        volumeMounts:
+          - name: {{ $volumeName }}
+            mountPath: {{ $sts.persistence.volumeMountPath }}
+
+          # Volume mounts from mountConfigMaps
+          {{- range $cm := $cntnr.mountConfigMaps }}
+          - name: {{$cm.name}}
+            mountPath: /{{ $cm.name }}
+          {{- end }}
+
+          # Volume mounts from mountSecrets
+          {{- range $sec := $cntnr.mountSecrets }}
+          - name: {{$sec.name}}
+            mountPath: /{{ $sec.name }}
+            readOnly: true
+          {{- end }}
+      {{- end }}
+      {{- end }} #{{/* range $kcntnr, $cntnr := $sts.containers */}}
+
+      {{- with $sts.initContainers }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+
+      {{- with $sts.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      {{- range $kcntnr, $cntnr := $sts.containers }}
+
+        - name: {{ $cntnr.name }}
+          image: "{{ $cntnr.image.repository }}:{{ $cntnr.image.tag }}"
+          imagePullPolicy: {{ default "IfNotPresent" $.Values.global.imagePullPolicy }}
+
+          {{- with $cntnr.envFrom }}
+          envFrom: {{- toYaml . | nindent 12}}
+          {{- end }}
+          {{- with $cntnr.env }}
+          env: {{- toYaml . | nindent 12}}
+          {{- end }}
+
+          {{- with $cntnr.workingDir }}
+          workingDir: {{ . }}
+          {{- end }}
+          {{- with $cntnr.command }}
+          command: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $cntnr.args }}
+          args: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $cntnr.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $cntnr.lifecycle }}
+          lifecycle: {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          ports:
+          {{- range $kprt, $prt := $cntnr.ports }}
+            - name:  {{ $prt.name}}
+              protocol: {{ $prt.protocol }}
+              containerPort: {{ $prt.port }}
+          {{- end }}
+
+          {{- if and $cntnr.healthProbes (not $cntnr.startupProbe) }}
+          startupProbe:
+            httpGet:
+              path: /health/startup
+              port: 9090
+            failureThreshold: 60
+            periodSeconds: 60
+          {{- else }}
+            {{- with (default (list ) $cntnr.startupProbe) }}
+          startupProbe: {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+
+          {{- if and $cntnr.healthProbes (not $cntnr.livenessProbe) }}
+          livenessProbe:
+            httpGet:
+              path: /health/liveness
+              port: 9090
+            failureThreshold: 2
+            periodSeconds: 15
+          {{- else }}
+            {{- with (default (list ) $cntnr.livenessProbe) }}
+          livenessProbe: {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+
+          {{- if and $cntnr.healthProbes (not $cntnr.readinessProbe) }}
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: 9090
+            failureThreshold: 1
+            periodSeconds: 15
+          {{- else }}
+            {{- with (default (list ) $cntnr.readinessProbe) }}
+          readinessProbe: {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+
+          volumeMounts:
+            - name: {{ $volumeName }}
+              mountPath: {{ $sts.persistence.volumeMountPath }}
+
+            {{- if $sts.persistence.extraPVC }}
+            - name: extra-data
+              mountPath: /extra-data
+            {{- end }}
+
+      {{- end }} # {{/* range $kcntnr, $cntnr := $sts.containers */}}
+
+      volumes:
+        {{- range $cmn := $stsCMNames }}
+        - name: {{$cmn}}
+          configMap:
+            name: {{$cmn}}
+        {{- end }}
+
+        {{- range $secn := $stsSecNames }}
+        - name: {{$secn}}
+          secret:
+            secretName: {{$secn}}
+            optional: false
+        {{- end }}
+
+        {{- if $sts.persistence.extraPVC }}
+        - name: extra-data
+          persistentVolumeClaim:
+            claimName: {{ $sts.persistence.extraPVC }}
+        {{- end }}
+
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ $volumeName }}
+      spec:
+        {{- if $sts.persistence.storageClassName }}
+        storageClassName: {{ $sts.persistence.storageClassName }}
+        {{- end }}
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ $sts.persistence.size | quote }}
+        {{- if $sts.persistence.gcpVolumeSnapshot }}
+        dataSource:
+          name: {{ $sts.persistence.gcpVolumeSnapshot | quote }}
+          kind: VolumeSnapshot
+          apiGroup: snapshot.storage.k8s.io
+        {{- end }}
+{{ end }} # {{/* range $ksts, $sts := $.Values.statefulset */}}


### PR DESCRIPTION
We need a more appropriate way to deploy portal workers associated with PVC
currently we are using a deployment with Volume mount but each time we update we run into mounting problems with the rolling update strategy