### PR TITLE
Replace secstore reference iteration list with project ID

### DIFF
--- a/charts/gcp-iam-externalsecrets/Chart.yaml
+++ b/charts/gcp-iam-externalsecrets/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: gcp-iam-externalsecrets
-version: 0.2.19
+version: 0.2.20
 description: A Helm chart to create a service account in your desired project, and grant it a specific role.

--- a/charts/gcp-iam-externalsecrets/templates/external-secrets.yaml
+++ b/charts/gcp-iam-externalsecrets/templates/external-secrets.yaml
@@ -8,7 +8,7 @@ spec:
   refreshInterval: 5s
   secretStoreRef:
     kind: SecretStore
-    name: {{ printf "secstore-%s" $v.project | trunc 63 | trimSuffix "-" }}
+    name: {{ printf "secstore-%s" $.Values.iamPolicy.gke.clusterProjectID | trunc 63 | trimSuffix "-" }}
   target:
     name: {{ $v.secret }}
     creationPolicy: Owner


### PR DESCRIPTION
# TL;DR

Interpolate the secstore name value from fixed, single project ID value.

## Summary

The current implementation for creating external secrets uses values from `iamPolicy.secretRoles` values, which comes from a list that looks like this:

```yaml
iamPolicy:
  secretRoles:
    - secret: secret-name
      project: portal-gcp-secrets
      role: roles/secretmanager.secretAccessor
```

From these values, external secret interpolates the values and returns an external secret with a SecretStore reference that looks like this:

```yaml
spec:
  refreshInterval: 5s
  secretStoreRef:
    kind: SecretStore
    name: secstore-portal-gcp-secrets
```

### The problem

Secret stores use a similar loop interpolation to create secret stores where they take the distinct values assigned in `iamPolicy.projectRoles` to create Secret Stores. With that reasoning in mind, a `values.yaml` files like this:

```yaml
projectRoles:
    - project: portal-gcp-project1
      role: roles/bigquery.user 
    - project: portal-gcp-project1
      role: roles/bigquery.dataEditor
    - project: portal-gcp-secrets
      role: roles/secretmanager.secretAccessor
```

Should give us in return the following secret stores:

```yaml
apiVersion: external-secrets.io/v1beta1
kind: SecretStore
metadata:
  name: secstore-portal-gcp-secrets
spec:
  provider:
    gcpsm:
      projectID: portal-gcp-secrets
      auth:
        workloadIdentity:
          clusterLocation: us-west1
          clusterName: portal-gcp-project1
          clusterProjectID: portal-gcp-project1
          serviceAccountRef:
            name: request-reporter-sa
---
apiVersion: external-secrets.io/v1beta1
kind: SecretStore
metadata:
  name: secstore-portal-gcp-project1
spec:
  provider:
    gcpsm:
      projectID: portal-gcp-project1
      auth:
        workloadIdentity:
          clusterLocation: us-west1
          clusterName: portal-gcp-project1
          clusterProjectID: portal-gcp-project1
          serviceAccountRef:
            name: request-reporter-sa
```

There are 3 major problems with current implementation:

- Secert Store creation depends on a list filled by 2 loops that read values from projects and secrets roles. :
```yaml
{{ $projects := list }}
{{ range $v := $.Values.iamPolicy.secretRoles }}
{{ $projects = append $projects $v.project }}
{{ end }}
{{ range $v := $.Values.iamPolicy.projectRoles }}
{{ $projects = append $projects $v.project }}
{{ end }}
```
- For a reason I still haven't figured out, K8s only takes the last secret store value from the list, therefore creates the secret store using that value (in all fairness, we really only need one secret store).
- The secret store that gets created relies in the fact that the list to be a 1 element list to be successfully referenced by the external secret. Otherwise, external secret will reference a non-existing secret store.

### The proposed solution

We have faced the problem of not being able to provide multiple roles to the created service account using this chart because of this erratic behavior, only capable of providing access to a single project to only read secrets.

This workaround proposes to use the `iamPolicy.gke.clusterProjectID` for the secret store reference. This value is used as the target project where the SA lives, allows the assignment of multiple project roles to it without compromising the reference of the external secret not being able to find the secret store.

### Testing and debugging

I've tested using below file `dummy.yaml` which simulates a scenario where a given SA will get SM permissions in one project and BQ permissions in another project:

```yaml
iamPolicy:
  secretRoles:
    - secret: prd-service-dummy
      project: portal-gcp-secrets
      role: roles/secretmanager.secretAccessor

  projectRoles:
    - project: portal-gcp-dummy
      role: roles/bigquery.user 
    - project: portal-gcp-dummy
      role: roles/bigquery.dataEditor
    - project: portal-gcp-secrets
      role: roles/secretmanager.secretAccessor

  gke:
    clusterLocation: us-west1
    clusterName: portal-gcp-dummy
    clusterProjectID: portal-gcp-dummy
    serviceAccount: service-dummy-sa

externalSecretStore:
  create: true

externalSecrets:
  create: true

disableConfigConnectorCRDs: true
```

Running `helm template --debug . -f dummy.yaml` returns the following manifest:

```yaml
---
# Source: gcp-iam-externalsecrets/templates/sa.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: service-dummy-sa
  annotations:
    iam.gke.io/gcp-service-account: "service-dummy-sa@portal-gcp-dummy.iam.gserviceaccount.com"
---
# Source: gcp-iam-externalsecrets/templates/external-secrets.yaml
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: sec-prd-service-dummy-portal-gcp-secrets
spec:
  refreshInterval: 5s
  secretStoreRef:
    kind: SecretStore
    name: secstore-portal-gcp-dummy
  target:
    name: prd-service-dummy
    creationPolicy: Owner
  dataFrom:
  - extract:
      conversionStrategy: Default
      decodingStrategy: None
      key: prd-service-dummy
---
# Source: gcp-iam-externalsecrets/templates/secretsstore.yaml
### portal-gcp-secrets
apiVersion: external-secrets.io/v1beta1
kind: SecretStore
metadata:
  name: secstore-portal-gcp-secrets
spec:
  provider:
    gcpsm:
      projectID: portal-gcp-secrets
      auth:
        workloadIdentity:
          clusterLocation: us-west1
          clusterName: portal-gcp-dummy
          clusterProjectID: portal-gcp-dummy
          serviceAccountRef:
            name: service-dummy-sa
### portal-gcp-dummy
apiVersion: external-secrets.io/v1beta1
kind: SecretStore
metadata:
  name: secstore-portal-gcp-dummy
spec:
  provider:
    gcpsm:
      projectID: portal-gcp-dummy
      auth:
        workloadIdentity:
          clusterLocation: us-west1
          clusterName: portal-gcp-dummy
          clusterProjectID: portal-gcp-dummy
          serviceAccountRef:
            name: service-dummy-sa
```