### PR TITLE
Fix/gcp iam externalsecrets chart

### DIFF
--- a/charts/gcp-iam-externalsecrets/Chart.yaml
+++ b/charts/gcp-iam-externalsecrets/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: gcp-iam-externalsecrets
-version: 0.2.21-rc
+version: 0.2.21
 description: A Helm chart to create a service account in your desired project, and grant it a specific role.

--- a/charts/gcp-iam-externalsecrets/Chart.yaml
+++ b/charts/gcp-iam-externalsecrets/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: gcp-iam-externalsecrets
-version: 0.2.20
+version: 0.2.21-rc
 description: A Helm chart to create a service account in your desired project, and grant it a specific role.

--- a/charts/gcp-iam-externalsecrets/Chart.yaml
+++ b/charts/gcp-iam-externalsecrets/Chart.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 name: gcp-iam-externalsecrets
 version: 0.2.21
 description: A Helm chart to create a service account in your desired project, and grant it a specific role.
+maintainers:
+  - name: Grove Infra team

--- a/charts/gcp-iam-externalsecrets/templates/external-secrets.yaml
+++ b/charts/gcp-iam-externalsecrets/templates/external-secrets.yaml
@@ -8,7 +8,7 @@ spec:
   refreshInterval: 5s
   secretStoreRef:
     kind: SecretStore
-    name: {{ printf "secstore-%s" $.Values.iamPolicy.gke.clusterProjectID | trunc 63 | trimSuffix "-" }}
+    name: {{ printf "secstore-%s" $v.project | trunc 63 | trimSuffix "-" }}
   target:
     name: {{ $v.secret }}
     creationPolicy: Owner

--- a/charts/gcp-iam-externalsecrets/templates/gcp-cnrm-iam.yaml
+++ b/charts/gcp-iam-externalsecrets/templates/gcp-cnrm-iam.yaml
@@ -4,9 +4,9 @@
 #* So adding this flag, to allow disabling them
 {{- if not .Values.disableConfigConnectorCRDs }}
 
-#* Secret level roles
-#* This section provides access to secrets manager iterating over a number of secrets and binds
-#* access to the designated SA created in the same section.
+# Secret level roles
+# This section provides access to secrets manager iterating over a number of secrets and binds
+# access to the designated SA created in the same section.
 {{- range $v := $.Values.iamPolicy.secretRoles }}
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
@@ -22,8 +22,8 @@ spec:
     external: "projects/{{ $v.project }}/secrets/{{ $v.secret }}"
 {{ end }}
 
-#* Project level roles
-#* Within this section additional permissions can be bound to the same SA using this section.
+# Project level roles
+# Within this section additional permissions can be bound to the same SA using this section.
 {{- range $v := $.Values.iamPolicy.projectRoles }}
 ---
 kind: IAMPolicyMember

--- a/charts/gcp-iam-externalsecrets/templates/gcp-cnrm-iam.yaml
+++ b/charts/gcp-iam-externalsecrets/templates/gcp-cnrm-iam.yaml
@@ -4,7 +4,9 @@
 #* So adding this flag, to allow disabling them
 {{- if not .Values.disableConfigConnectorCRDs }}
 
-# Secret level roles
+#* Secret level roles
+#* This section provides access to secrets manager iterating over a number of secrets and binds
+#* access to the designated SA created in the same section.
 {{- range $v := $.Values.iamPolicy.secretRoles }}
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
@@ -20,7 +22,8 @@ spec:
     external: "projects/{{ $v.project }}/secrets/{{ $v.secret }}"
 {{ end }}
 
-# Project level roles
+#* Project level roles
+#* Within this section additional permissions can be bound to the same SA using this section.
 {{- range $v := $.Values.iamPolicy.projectRoles }}
 ---
 kind: IAMPolicyMember

--- a/charts/gcp-iam-externalsecrets/templates/secretsstore.yaml
+++ b/charts/gcp-iam-externalsecrets/templates/secretsstore.yaml
@@ -4,9 +4,6 @@
 {{ range $v := $.Values.iamPolicy.secretRoles }}
 {{ $projects = append $projects $v.project }}
 {{ end }}
-{{ range $v := $.Values.iamPolicy.projectRoles }}
-{{ $projects = append $projects $v.project }}
-{{ end }}
 
 {{ range $p := uniq $projects }}
 ### {{$p}}


### PR DESCRIPTION
# TL;DR

Continuing on fixing externalsecret erratic behavior when creating secret stores.

## Summary

Previous fix didn't seem to actually solve the underlying issue - erratic naming when using multiple projects - despite of using the fixed naming of the target project.

Following the multiple secret store logic from the past, it seems that using all project names we may include in the chart doesn't make that much sense to be included in secret stores iteration since, at the end of the day, ESO will end up creating a single secret store.

That said, I went ahead and removed the second iteration used to create secret store. This move will prevent the chart to have multiple project values which may not be part of the secret role section, therefore preventing it to create secret stores with names that might not match with the reference that external secret resource will use.

Additionally, the value used to reference the secret store in the external secret resource has been rolled back to actually use the project value from iteration.