### PR TITLE
Moved GCPHTTPSLoadBalancer config to the container section

### DIFF
--- a/charts/blockchain-node/Chart.yaml
+++ b/charts/blockchain-node/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to deploy a blockchain node
 
 type: application
 
-version: 0.1.6
+version: 0.1.7
 # Not compatible with 0.0.1 due to change container.command
 
 appVersion: "1.16.0"
@@ -12,3 +12,4 @@ appVersion: "1.16.0"
 maintainers:
   - name: pokt-foundation
   - name: vlad
+  - name: HebertCL

--- a/charts/blockchain-node/example-values.yaml
+++ b/charts/blockchain-node/example-values.yaml
@@ -93,6 +93,7 @@ statefulset:
           --datadir=/home/app/.pocket \
           --mainnet \
           --keybase=false"
+        GCPHTTPSLoadBalancer: true
         ports:
           - name: tendermint
             type: ClusterIP

--- a/charts/blockchain-node/templates/service.yaml
+++ b/charts/blockchain-node/templates/service.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     {{- include "blockchain-node.labels" $ | nindent 4 }}
 
-{{- if .GCPHTTPSLoadBalancer }}
+{{- if $cntnr.GCPHTTPSLoadBalancer }}
   annotations:
     cloud.google.com/backend-config: '{"default": "{{ include "blockchain-node.fullname" $ }}-{{ $prt.name }}"}'
 {{- end }}


### PR DESCRIPTION
# TL;DR

`GCPHTTPSLoadBalancer` which was previously assigned to the root values moved to container specific config to prevent all services created by the chart to create backend services.